### PR TITLE
刪除已由 github.copilot.enable 替代之過時的 github.copilot.editor.enableAutoCompletions 設定

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,6 @@
     "chat.commandCenter.enabled": true,
 
     "github.copilot.selectedCompletionModel": "gpt-4o-copilot",
-    "github.copilot.editor.enableAutoCompletions": true,
     "github.copilot.editor.enableCodeActions": true,
     "github.copilot.renameSuggestions.triggerAutomatically": true,
     "workbench.commandPalette.experimental.askChatLocation": "chatView",

--- a/README.md
+++ b/README.md
@@ -113,12 +113,6 @@ GitHub Copilot 的功能是透過安裝**擴充套件**來實現的，你需要�
         
         > 你也可以用 `F1` > `GitHub Copilot: Change Completion Model` 選擇。
 
-      * `github.copilot.editor.enableAutoCompletions` 設定為 `true`
-
-        啟用程式碼自動補全功能，也就是 Inline 自動完成功能。
-
-        因為自動完成功能經常會提供錯誤的提示，有些人會選擇關閉這個選項。
-
       * `github.copilot.editor.enableCodeActions` 設定為 `true`
 
         控制 Copilot 命令在可用時是否顯示為 **Code Actions** (程式碼動作)


### PR DESCRIPTION
在 VS Code 正式版也是有這個告警，代表可以安全刪除了。